### PR TITLE
Transform anonymous default exports

### DIFF
--- a/src/__tests__/baselines/ssr/sample1.ts.baseline
+++ b/src/__tests__/baselines/ssr/sample1.ts.baseline
@@ -81,13 +81,13 @@ TypeScript after transform:
   const SuperButton = Button.extend.withConfig({ displayName: "SuperButton", componentId: "sc-10xv1bi" }) \`
     color: super;
   \`;
-  export default styled.link \`
+  export default styled.link.withConfig({ componentId: "sc-iechwg" }) \`
     color: black;
   \`;
-  export const SmallButton = Button.extend.withConfig({ displayName: "SmallButton", componentId: "sc-8sh5f7" }) \`
+  export const SmallButton = Button.extend.withConfig({ displayName: "SmallButton", componentId: "sc-3ane8u" }) \`
     font-size: .7em;
   \`;
-  const MiniButton = styled(SmallButton).attrs({ size: "mini" }).withConfig({ displayName: "MiniButton", componentId: "sc-v7haos" }) \`
+  const MiniButton = styled(SmallButton).attrs({ size: "mini" }).withConfig({ displayName: "MiniButton", componentId: "sc-12a48t6" }) \`
     font-size: .1em;
   \`;
   

--- a/src/__tests__/baselines/ssr/style-objects.ts.baseline
+++ b/src/__tests__/baselines/ssr/style-objects.ts.baseline
@@ -81,13 +81,13 @@ TypeScript after transform:
   const SuperButton = Button.extend.withConfig({ displayName: "SuperButton", componentId: "sc-1t5v351" })({
       color: 'super'
   });
-  export default styled.link({
+  export default styled.link.withConfig({ componentId: "sc-115bov" })({
       color: 'black'
   });
-  export const SmallButton = Button.extend.withConfig({ displayName: "SmallButton", componentId: "sc-ftk9hu" })({
+  export const SmallButton = Button.extend.withConfig({ displayName: "SmallButton", componentId: "sc-blt0bk" })({
       fontSize: '.7em'
   });
-  const MiniButton = styled(SmallButton).attrs({ size: "mini" }).withConfig({ displayName: "MiniButton", componentId: "sc-15rszef" })({
+  const MiniButton = styled(SmallButton).attrs({ size: "mini" }).withConfig({ displayName: "MiniButton", componentId: "sc-96ogu9" })({
       fontSize: '.1em'
   });
   

--- a/src/createTransformer.ts
+++ b/src/createTransformer.ts
@@ -177,7 +177,7 @@ export function createTransformer({
                         || isCallExpression(node.parent)
                     )
                     && node.parent.parent
-                    && isVariableDeclaration(node.parent.parent)
+                    && (isVariableDeclaration(node.parent.parent) || isExportAssignment(node.parent.parent))
                     && isStyledFunction(node, identifiers)
                 ) {
 


### PR DESCRIPTION
This change ensures that the plugin also transforms occurrences of `export default styled(Thing)`